### PR TITLE
Enable parallel OCR processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@ A comprehensive Python tool to automate the workflow of converting DJVU/PDF file
 - **Dual Page Numbering System**: Display both book page numbers and PDF page numbers in all output files when a page offset is used
 - **macOS-like Directory Naming**: Create uniquely named directories with incremented suffixes (e.g., "Book Name (1)") when processing the same book multiple times
 - **Automated Processing**: Scripts for automating the book processing workflow with predefined inputs
+- **Parallel OCR Processing**: Utilize multiple CPU cores to speed up OCR on large books
 
 ## Features
 
 - Convert DJVU files to PDF (using PyMuPDF)
 - Extract PNG images from PDF (using PyMuPDF)
 - Perform OCR on images to extract text (using tesseract)
+- Accelerated OCR with parallel processing
 - Organize text files into chapters with proper formatting
 - Group chapters into combined files optimizing for file size
 - Create an index file for easy navigation

--- a/main.py
+++ b/main.py
@@ -439,7 +439,7 @@ def main():
     print(f"\nPerforming OCR on images to {dirs['text']}")
     
     ocr = OCRProcessor()
-    success, message, text_files = ocr.process_images(
+    success, message, text_files = ocr.process_images_parallel(
         image_files, dirs['text'], language='eng', prefix='page'
     )
     


### PR DESCRIPTION
## Summary
- add a helper for multiprocessing OCR
- implement `process_images_parallel` in `OCRProcessor`
- call the parallel OCR method from `main.py`
- document the new feature in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849a00f56bc8332a4458bad481c3d05