### PR TITLE
Add parallel PNG extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ A comprehensive Python tool to automate the workflow of converting DJVU/PDF file
 - **macOS-like Directory Naming**: Create uniquely named directories with incremented suffixes (e.g., "Book Name (1)") when processing the same book multiple times
 - **Automated Processing**: Scripts for automating the book processing workflow with predefined inputs
 - **Parallel OCR Processing**: Utilize multiple CPU cores to speed up OCR on large books
+- **Parallel PNG Extraction**: Create PNG pages faster using multiple CPU cores
 
 ## Features
 
 - Convert DJVU files to PDF (using PyMuPDF)
 - Extract PNG images from PDF (using PyMuPDF)
+- Accelerated PNG extraction with parallel processing
 - Perform OCR on images to extract text (using tesseract)
 - Accelerated OCR with parallel processing
 - Organize text files into chapters with proper formatting

--- a/main.py
+++ b/main.py
@@ -423,8 +423,12 @@ def main():
     progress.start_step()
     print(f"\nExtracting PNG images from PDF to {dirs['images']}")
     
-    success, message, image_files = extractor.extract_images(
-        pdf_path, dirs['images'], dpi=300, format='png', prefix='page'
+    success, message, image_files = extractor.extract_images_parallel(
+        pdf_path,
+        dirs['images'],
+        dpi=300,
+        format='png',
+        prefix='page',
     )
     
     if not success:


### PR DESCRIPTION
## Summary
- enable parallel PNG extraction using multiple CPU cores
- call parallel extraction in main workflow
- document the new parallel PNG feature

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py --help` *(fails: ModuleNotFoundError: No module named 'PyPDF2')*

------
https://chatgpt.com/codex/tasks/task_e_6849cb3561048332a6b81bf43d4c1657