### PR TITLE
Add EPUB/MOBI support and text extraction

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -24,6 +24,12 @@ If you have Chocolatey installed, you can install all dependencies with administ
 2. Run the installer and ensure the tools are added to your PATH
 3. Verify installation with: `ddjvu --version`
 
+### Calibre (ebook-convert)
+
+1. Download Calibre from [Calibre website](https://calibre-ebook.com/download)
+2. Install and ensure `ebook-convert` is added to your PATH
+3. Verify installation with: `ebook-convert --version`
+
 
 ## Verifying Installation
 
@@ -32,6 +38,7 @@ After installing all dependencies, run the following commands to verify the tool
 ```bash
 tesseract --version
 ddjvu --version
+ebook-convert --version
 ```
 
 If all commands return version information or help text, the dependencies are correctly installed.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Book Processor
 
-A comprehensive Python tool to automate the workflow of converting DJVU/PDF files into organized directories with PNG and text files, then combining text files into chapters and groups optimized for LLM consumption.
+A comprehensive Python tool to automate the workflow of converting DJVU/PDF/EPUB/MOBI files into organized directories with PNG and text files, then combining text files into chapters and groups optimized for LLM consumption.
 
 ## Recent Enhancements
 
@@ -10,12 +10,14 @@ A comprehensive Python tool to automate the workflow of converting DJVU/PDF file
 - **Parallel OCR Processing**: Utilize multiple CPU cores to speed up OCR on large books
 - **Parallel PNG Extraction**: Create PNG pages faster using multiple CPU cores
 
-## Features
+-## Features
 
 - Convert DJVU files to PDF (using DjVuLibre's `ddjvu`)
+- Convert EPUB/MOBI files to PDF (using Calibre's `ebook-convert`)
 - Extract PNG images from PDF (using PyMuPDF)
 - Accelerated PNG extraction with parallel processing
 - Perform OCR on images to extract text (using tesseract)
+- Extract text directly from digital PDFs and converted EPUB/MOBI
 - Accelerated OCR with parallel processing
 - Organize text files into chapters with proper formatting
 - Group chapters into combined files optimizing for file size
@@ -29,6 +31,7 @@ A comprehensive Python tool to automate the workflow of converting DJVU/PDF file
 
 - **tesseract-ocr**: For OCR processing
 - **djvulibre**: Provides the `ddjvu` tool for DJVU to PDF conversion
+- **Calibre**: Provides the `ebook-convert` tool for EPUB/MOBI to PDF conversion
 
 ### Python Dependencies
 
@@ -73,8 +76,8 @@ python main.py
 
 The script will guide you through the following steps:
 
-1. Select an input file (PDF or DJVU)
-2. Convert DJVU to PDF if necessary
+1. Select an input file (PDF, DJVU, EPUB, or MOBI)
+2. Convert DJVU/EPUB/MOBI to PDF if necessary
 3. Open the PDF for reference
 4. Enter chapter start pages
 5. Provide chapter titles and descriptions

--- a/processors/converter.py
+++ b/processors/converter.py
@@ -15,11 +15,16 @@ class FormatConverter:
 
     def __init__(self):
         self.has_ddjvu = check_command_exists("ddjvu")
+        self.has_ebook_convert = check_command_exists("ebook-convert")
 
     def check_dependencies(self):
         """Check if required dependencies are installed."""
+        if not self.has_ddjvu and not self.has_ebook_convert:
+            return False, "ddjvu or ebook-convert command not found."
         if not self.has_ddjvu:
             return False, "ddjvu command not found."
+        if not self.has_ebook_convert:
+            return False, "ebook-convert command not found."
         return True, "All dependencies found."
 
     def install_dependencies_guide(self):
@@ -31,7 +36,30 @@ class FormatConverter:
             instructions += "- macOS: Run 'brew install djvulibre'\n"
             instructions += "- Linux (Debian/Ubuntu): Run 'sudo apt-get install djvulibre-bin'\n"
             instructions += "- Linux (Fedora): Run 'sudo dnf install djvulibre'\n\n"
+        if not self.has_ebook_convert:
+            instructions += "Calibre Installation (provides ebook-convert):\n"
+            instructions += "- Visit https://calibre-ebook.com/download to download and install Calibre\n\n"
         return instructions
+
+    def ebook_to_pdf(self, ebook_path, output_pdf_path):
+        """Convert an EPUB or MOBI file to PDF using ebook-convert."""
+        if not self.has_ebook_convert:
+            return False, "ebook-convert command not available. Cannot convert ebook to PDF."
+
+        try:
+            cmd = ["ebook-convert", ebook_path, output_pdf_path]
+            result = subprocess.run(
+                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+            )
+            if result.returncode != 0:
+                return False, f"ebook-convert failed: {result.stderr.strip()}"
+
+            if not os.path.exists(output_pdf_path):
+                return False, "Conversion failed: Output PDF not created"
+
+            return True, f"Successfully converted ebook to PDF at {output_pdf_path}"
+        except Exception as e:
+            return False, f"Exception during ebook to PDF conversion: {str(e)}"
 
     def djvu_to_pdf(self, djvu_path, output_pdf_path, quality=50):
         """Convert a DJVU file to PDF using the ddjvu command."""

--- a/utils/validation.py
+++ b/utils/validation.py
@@ -26,8 +26,8 @@ def validate_input_file(filepath):
     _, ext = os.path.splitext(filepath)
     ext = ext.lower()
     
-    if ext not in ['.pdf', '.djvu']:
-        return False, f"Unsupported file format: {ext}. Only .pdf and .djvu are supported.", None
+    if ext not in ['.pdf', '.djvu', '.epub', '.mobi']:
+        return False, f"Unsupported file format: {ext}. Only .pdf, .djvu, .epub and .mobi are supported.", None
     
     # Remove the dot from extension
     file_type = ext[1:]


### PR DESCRIPTION
## Summary
- add epub and mobi formats to validation
- support converting ebooks via ebook-convert
- extract text directly from PDF when OCR not needed
- update main workflow for new formats
- document Calibre dependency and new usage in README and INSTALLATION guides

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684cb336790483329e5a72ad40b798d8